### PR TITLE
Add Native sdk usage demo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: android
+jdk:
+  - oraclejdk8
 android:
   components:
   - tools
-  - build-tools-23.0.2
-  - android-23
+  - build-tools-24.0.2
+  - android-24
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
-  - addon-google_apis-google-23
+  - addon-google_apis-google-24
 script:
 - "./gradlew clean test --continue"
 branches:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Lock lock = builder.withProviderResolver(authHandler);
 
 That's it! When **Lock** needs to authenticate using that connection name, it will ask the `AuthProviderResolver` for a valid `AuthProvider`.
 
+> We provide this demo in the `PhotosActivity` class. We also use the Facebook SDK to get the User Albums and show them on a list.
+
 ### Without Lock
 
 Just create a new instance of `FacebookAuthProvider` with an `AuthenticationAPIClient`.
@@ -103,6 +105,8 @@ provider.start(this, callback, RC_PERMISSIONS, RC_AUTHENTICATION);
 ```
 
 That's it! You'll receive the result in the `AuthCallback` you passed.
+
+> We provide this demo in the `SimpleActivity` class.
 
 ## Using a custom connection name
 To use a custom social connection name to authorize against Auth0, call `setConnection` with your new connection name.

--- a/README.md
+++ b/README.md
@@ -42,37 +42,28 @@ The value `@string/facebook_app_id` is your Facebook Application ID that you can
 
 ### With Lock
 
-Create a new class and make it implement `AuthProviderResolver`. On the `onAuthProviderRequest` method compare the `connectionName` value against the connection you would like this provider to handle, and if it's a match return a new `FacebookAuthProvider` instance with an `AuthenticationAPIClient`.
-
+This library includes an implementation of the `AuthHandler` interface for you to use it directly with **Lock**. Create a new instance of the `FacebookAuthHandler` class passing a valid `FacebookAuthProvider`. Don't forget to customize the permissions if you need to. 
+ 
 ```java
-public class AuthHandler implements AuthProviderResolver {
+Auth0 auth0 = new Auth0("auth0-client-id", "auth0-domain");
 
-    @Nullable
-    @Override
-    public AuthProvider onAuthProviderRequest(Context context, @NonNull AuthCallback callback, @NonNull String connectionName) {
-        AuthProvider provider = null;
-        if (connectionName.equals("facebook")) {
-            Auth0 auth0 = new Auth0("auth0-client-id", "auth0-domain");
-            final AuthenticationAPIClient client = new AuthenticationAPIClient(auth0);
-            provider = new FacebookAuthProvider(client);
-        }
-        return provider;
-    }
-}
+FacebookAuthProvider provider = new FacebookAuthProvider(new AuthenticationAPIClient(auth0));
+provider.setPermissions(Arrays.asList("public_profile", "user_photos"));
+provider.forceRequestAccount(true);
 
+FacebookAuthHandler handler = new FacebookAuthHandler(provider);
 ```
 
-Make a new instance of your provider resolver and set it when building the Lock instance.
+Finally in the Lock Builder, call `withAuthHandlers` passing the recently created instance. 
 
 ```java
-final AuthHandler authHandler = new AuthHandler(); 
-final Lock.Builder builder = Lock.newBuilder(getAccount(), callback);
-Lock lock = builder.withProviderResolver(authHandler);
-                //...
-                .build();
+lock = Lock.newBuilder(auth0, authCallback)
+        .withAuthHandlers(handler)
+        //...
+        .build(this);
 ```
 
-That's it! When **Lock** needs to authenticate using that connection name, it will ask the `AuthProviderResolver` for a valid `AuthProvider`.
+That's it! When **Lock** needs to authenticate using that connection name, it will ask the `FacebookAuthHandler` for a valid `AuthProvider`.
 
 > We provide this demo in the `PhotosActivity` class. We also use the Facebook SDK to get the User Albums and show them on a list.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Lock-Facebook is available through [Maven Central](http://search.maven.org) 
 compile 'com.auth0.android:lock-facebook:2.4.+'
 ```
 
-Then in your project's `AndroidManifest.xml` add the following entries:
+Then in your project's `AndroidManifest.xml` inside the application tag, add the following entries:
 
 ```xml
 <activity android:name="com.facebook.FacebookActivity"
@@ -113,6 +113,13 @@ To use a custom social connection name to authorize against Auth0, call `setConn
 
 ```java
 provider.setConnection("my-connection")
+```
+
+## Requesting custom Permissions
+By default, the permission `public_profile` is requested. You can customize them by calling `setPermissions` with the list of Permissions.
+
+```java
+provider.setPermissions(Arrays.asList("public_profile", "user_photos"));
 ```
 
 ## Log out / Clear account.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-facebook')
-    compile 'com.auth0.android:lock:2.0.0-beta.3'
+    compile 'com.auth0.android:lock:2.0.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:support-v4:24.1.1'
+    compile 'com.android.support:support-v4:24.2.1'
     compile libraries.app_compat
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,5 +27,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-facebook')
+    compile 'com.auth0.android:lock:2.0.0-beta.3'
+    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.android.support:support-v4:24.1.1'
     compile libraries.app_compat
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,19 +10,48 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+
+        <activity android:name=".ChooserActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".SimpleActivity"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".PhotosActivity"
+            android:screenOrientation="portrait" />
 
-        <activity android:name="com.facebook.FacebookActivity"
+        <activity
+            android:name="com.auth0.android.lock.LockActivity"
+            android:label="@string/app_name"
+            android:launchMode="singleTask"
+            android:screenOrientation="portrait"
+            android:theme="@style/Lock.Theme">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="@string/com_auth0_domain"
+                    android:pathPrefix="/android/com.auth0.android.facebook.app/callback"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+
+        <activity
+            android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar"
-            android:label="@string/app_name" />
-        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
+            android:label="@string/app_name"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <meta-data
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_app_id" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/auth0/android/facebook/app/ChooserActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/ChooserActivity.java
@@ -1,0 +1,31 @@
+package com.auth0.android.facebook.app;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+
+public class ChooserActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chooser);
+        Button tokenLogin = (Button) findViewById(R.id.tokenLoginButton);
+        tokenLogin.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(ChooserActivity.this, SimpleActivity.class));
+            }
+        });
+        Button photosLogin = (Button) findViewById(R.id.photosLoginButton);
+        photosLogin.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(ChooserActivity.this, PhotosActivity.class));
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
@@ -1,0 +1,154 @@
+package com.auth0.android.facebook.app;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.GridView;
+import android.widget.ProgressBar;
+
+import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.facebook.FacebookAuthProvider;
+import com.auth0.android.lock.AuthenticationCallback;
+import com.auth0.android.lock.Lock;
+import com.auth0.android.lock.LockCallback;
+import com.auth0.android.lock.provider.AuthProviderResolver;
+import com.auth0.android.lock.utils.LockException;
+import com.auth0.android.provider.AuthCallback;
+import com.auth0.android.provider.AuthProvider;
+import com.auth0.android.result.Credentials;
+import com.facebook.AccessToken;
+import com.facebook.GraphRequest;
+import com.facebook.GraphResponse;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class PhotosActivity extends AppCompatActivity {
+
+    private static final String TAG = PhotosActivity.class.getSimpleName();
+    private static final String FACEBOOK_CONNECTION = "facebook";
+
+    private Lock lock;
+    private PhotosAdapter adapter;
+    private List<String> photos;
+    private ProgressBar progressBar;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_photos);
+
+        lock = Lock.newBuilder(getAccount(), authCallback)
+                .withProviderResolver(providerResolver)
+                .onlyUseConnections(Collections.singletonList(FACEBOOK_CONNECTION))
+                .closable(true)
+                .build();
+        lock.onCreate(this);
+
+
+        Button loginButton = (Button) findViewById(R.id.loginButton);
+        loginButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(lock.newIntent(PhotosActivity.this));
+            }
+        });
+        progressBar = (ProgressBar) findViewById(R.id.progressBar);
+        photos = new ArrayList<>();
+        adapter = new PhotosAdapter(this, photos);
+        GridView gridView = (GridView) findViewById(R.id.grid);
+        gridView.setAdapter(adapter);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        lock.onDestroy(this);
+        lock = null;
+    }
+
+    private Auth0 getAccount() {
+        return new Auth0(getString(R.string.com_auth0_client_id), getString(R.string.com_auth0_domain));
+    }
+
+    private void fetchAlbums() {
+        GraphRequest request = GraphRequest.newMeRequest(AccessToken.getCurrentAccessToken(),
+                new GraphRequest.GraphJSONObjectCallback() {
+                    @Override
+                    public void onCompleted(JSONObject object, GraphResponse response) {
+                        try {
+                            final List<String> urls = parseAlbumData(object.getJSONObject("albums").getJSONArray("data"));
+                            photos.addAll(urls);
+                            adapter.notifyDataSetChanged();
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                        progressBar.setVisibility(View.GONE);
+                    }
+                });
+        Bundle parameters = new Bundle();
+        parameters.putString("fields", "name,albums.limit(100){name,picture{url}}");
+        request.setParameters(parameters);
+        request.executeAsync();
+    }
+
+    private List<String> parseAlbumData(JSONArray albumData) {
+        List<String> covers = new ArrayList<>();
+        for (int i = 0; i < albumData.length(); i++) {
+            try {
+                covers.add(albumData
+                        .getJSONObject(i)
+                        .getJSONObject("picture")
+                        .getJSONObject("data")
+                        .getString("url"));
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+        return covers;
+    }
+
+    private LockCallback authCallback = new AuthenticationCallback() {
+        @Override
+        public void onAuthentication(Credentials credentials) {
+            Log.i(TAG, "Auth ok! User has given us all facebook requested permissions.");
+            progressBar.setVisibility(View.VISIBLE);
+            fetchAlbums();
+        }
+
+        @Override
+        public void onCanceled() {
+        }
+
+        @Override
+        public void onError(LockException error) {
+            Log.e(TAG, "Error occurred: " + error.getMessage());
+        }
+    };
+
+    private AuthProviderResolver providerResolver = new AuthProviderResolver() {
+        @Nullable
+        @Override
+        public AuthProvider onAuthProviderRequest(Context context, @NonNull AuthCallback callback, @NonNull String connectionName) {
+            if (FACEBOOK_CONNECTION.equals(connectionName)) {
+                AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
+                FacebookAuthProvider facebookProvider = new FacebookAuthProvider(client);
+                facebookProvider.setPermissions(Arrays.asList("public_profile", "user_photos"));
+                return facebookProvider;
+            }
+            return null;
+        }
+    };
+}

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.GridView;
 import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
@@ -88,14 +89,19 @@ public class PhotosActivity extends AppCompatActivity {
                 new GraphRequest.GraphJSONObjectCallback() {
                     @Override
                     public void onCompleted(JSONObject object, GraphResponse response) {
+                        progressBar.setVisibility(View.GONE);
                         try {
                             final List<String> urls = parseAlbumData(object.getJSONObject("albums").getJSONArray("data"));
+                            if (urls.isEmpty()) {
+                                Toast.makeText(PhotosActivity.this, "You have no albums on Facebook!", Toast.LENGTH_LONG).show();
+                                return;
+                            }
+                            photos.clear();
                             photos.addAll(urls);
                             adapter.notifyDataSetChanged();
                         } catch (Exception e) {
                             e.printStackTrace();
                         }
-                        progressBar.setVisibility(View.GONE);
                     }
                 });
         Bundle parameters = new Bundle();
@@ -130,10 +136,12 @@ public class PhotosActivity extends AppCompatActivity {
 
         @Override
         public void onCanceled() {
+            Toast.makeText(PhotosActivity.this, "Authentication cancelled", Toast.LENGTH_SHORT).show();
         }
 
         @Override
         public void onError(LockException error) {
+            Toast.makeText(PhotosActivity.this, "Error occurred. Please retry.", Toast.LENGTH_SHORT).show();
             Log.e(TAG, "Error occurred: " + error.getMessage());
         }
     };

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
@@ -146,6 +146,7 @@ public class PhotosActivity extends AppCompatActivity {
                 AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
                 FacebookAuthProvider facebookProvider = new FacebookAuthProvider(client);
                 facebookProvider.setPermissions(Arrays.asList("public_profile", "user_photos"));
+                facebookProvider.forceRequestAccount(true);
                 return facebookProvider;
             }
             return null;

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
@@ -1,8 +1,6 @@
 package com.auth0.android.facebook.app;
 
-import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -14,14 +12,12 @@ import android.widget.Toast;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.facebook.FacebookAuthHandler;
 import com.auth0.android.facebook.FacebookAuthProvider;
 import com.auth0.android.lock.AuthenticationCallback;
 import com.auth0.android.lock.Lock;
 import com.auth0.android.lock.LockCallback;
-import com.auth0.android.lock.provider.AuthProviderResolver;
 import com.auth0.android.lock.utils.LockException;
-import com.auth0.android.provider.AuthCallback;
-import com.auth0.android.provider.AuthProvider;
 import com.auth0.android.result.Credentials;
 import com.facebook.AccessToken;
 import com.facebook.GraphRequest;
@@ -51,13 +47,14 @@ public class PhotosActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photos);
 
+        FacebookAuthProvider provider = new FacebookAuthProvider(new AuthenticationAPIClient(getAccount()));
+        provider.setPermissions(Arrays.asList("public_profile", "user_photos"));
+        provider.forceRequestAccount(true);
         lock = Lock.newBuilder(getAccount(), authCallback)
-                .withProviderResolver(providerResolver)
-                .onlyUseConnections(Collections.singletonList(FACEBOOK_CONNECTION))
+                .withAuthHandlers(new FacebookAuthHandler(provider))
+                .allowedConnections(Collections.singletonList(FACEBOOK_CONNECTION))
                 .closable(true)
-                .build();
-        lock.onCreate(this);
-
+                .build(this);
 
         Button loginButton = (Button) findViewById(R.id.loginButton);
         loginButton.setOnClickListener(new View.OnClickListener() {
@@ -143,21 +140,6 @@ public class PhotosActivity extends AppCompatActivity {
         public void onError(LockException error) {
             Toast.makeText(PhotosActivity.this, "Error occurred. Please retry.", Toast.LENGTH_SHORT).show();
             Log.e(TAG, "Error occurred: " + error.getMessage());
-        }
-    };
-
-    private AuthProviderResolver providerResolver = new AuthProviderResolver() {
-        @Nullable
-        @Override
-        public AuthProvider onAuthProviderRequest(Context context, @NonNull AuthCallback callback, @NonNull String connectionName) {
-            if (FACEBOOK_CONNECTION.equals(connectionName)) {
-                AuthenticationAPIClient client = new AuthenticationAPIClient(getAccount());
-                FacebookAuthProvider facebookProvider = new FacebookAuthProvider(client);
-                facebookProvider.setPermissions(Arrays.asList("public_profile", "user_photos"));
-                facebookProvider.forceRequestAccount(true);
-                return facebookProvider;
-            }
-            return null;
         }
     };
 }

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosAdapter.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosAdapter.java
@@ -1,0 +1,48 @@
+package com.auth0.android.facebook.app;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+
+import com.bumptech.glide.Glide;
+
+import java.util.List;
+
+public class PhotosAdapter extends BaseAdapter {
+
+    private final Context context;
+    private final List<String> photos;
+
+    public PhotosAdapter(Context context, List<String> photos) {
+        this.context = context;
+        this.photos = photos;
+    }
+
+    @Override
+    public int getCount() {
+        return photos.size();
+    }
+
+    @Override
+    public Object getItem(int position) {
+        return photos.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        if (convertView == null) {
+            convertView = LayoutInflater.from(context).inflate(R.layout.item_photo, parent, false);
+        }
+        ImageView image = (ImageView) convertView.findViewById(R.id.image);
+        Glide.with(context).load(photos.get(position)).into(image);
+        return convertView;
+    }
+}

--- a/app/src/main/java/com/auth0/android/facebook/app/SimpleActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/SimpleActivity.java
@@ -43,9 +43,9 @@ import com.auth0.android.provider.AuthCallback;
 import com.auth0.android.result.Credentials;
 
 
-public class MainActivity extends AppCompatActivity implements View.OnClickListener {
+public class SimpleActivity extends AppCompatActivity implements View.OnClickListener {
 
-    private static final String TAG = MainActivity.class.getName();
+    private static final String TAG = SimpleActivity.class.getName();
     private static final int RC_PERMISSIONS = 110;
     private static final int RC_AUTHENTICATION = 111;
 
@@ -56,7 +56,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        setContentView(R.layout.activity_simple);
 
         message = (TextView) findViewById(R.id.textView);
         Button loginButton = (Button) findViewById(R.id.loginButton);
@@ -85,7 +85,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
-                        AlertDialog dialog = new AlertDialog.Builder(MainActivity.this)
+                        AlertDialog dialog = new AlertDialog.Builder(SimpleActivity.this)
                                 .setTitle(titleResource)
                                 .setMessage(messageResource)
                                 .create();
@@ -124,7 +124,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (provider.authorize(requestCode, resultCode, data)) {
+        if (requestCode == RC_AUTHENTICATION) {
+            provider.authorize(requestCode, resultCode, data);
             return;
         }
         super.onActivityResult(requestCode, resultCode, data);

--- a/app/src/main/java/com/auth0/android/facebook/app/SimpleActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/SimpleActivity.java
@@ -29,7 +29,6 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
@@ -38,6 +37,7 @@ import android.widget.TextView;
 
 import com.auth0.android.Auth0;
 import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.AuthenticationException;
 import com.auth0.android.facebook.FacebookAuthProvider;
 import com.auth0.android.provider.AuthCallback;
 import com.auth0.android.result.Credentials;
@@ -80,14 +80,14 @@ public class SimpleActivity extends AppCompatActivity implements View.OnClickLis
             }
 
             @Override
-            public void onFailure(@StringRes final int titleResource, @StringRes final int messageResource, Throwable cause) {
-                Log.e(TAG, "Failed with message " + getString(messageResource), cause);
+            public void onFailure(final AuthenticationException exception) {
+                Log.e(TAG, "Failed with message " + exception.getMessage());
                 runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
                         AlertDialog dialog = new AlertDialog.Builder(SimpleActivity.this)
-                                .setTitle(titleResource)
-                                .setMessage(messageResource)
+                                .setTitle(R.string.com_auth0_facebook_authentication_failed_title)
+                                .setMessage(exception.getMessage())
                                 .create();
                         dialog.show();
                     }

--- a/app/src/main/res/layout/activity_chooser.xml
+++ b/app/src/main/res/layout/activity_chooser.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ activity_simple.xmlml
+  ~
+  ~ Copyright (c) 2015 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".SimpleActivity">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:gravity="center_horizontal"
+        android:text="This demo shows how to log in using the Facebook Native Social Authentication Provider."
+        android:textSize="20sp" />
+
+    <Button
+        android:id="@+id/tokenLoginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="Simple Log In (TOKEN)" />
+
+    <Button
+        android:id="@+id/photosLoginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/tokenLoginButton"
+        android:layout_centerHorizontal="true"
+        android:text="Log In Using Lock (PHOTO ALBUMS)" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_photos.xml
+++ b/app/src/main/res/layout/activity_photos.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ activity_simplele.xml
+  ~
+  ~ Copyright (c) 2015 Auth0 (http://auth0.com)
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".SimpleActivity">
+
+    <Button
+        android:id="@+id/loginButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:text="Log in with Facebook" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        style="@style/Base.Widget.AppCompat.ProgressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:indeterminate="true"
+        android:visibility="invisible" />
+
+    <GridView
+        android:id="@+id/grid"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@id/loginButton"
+        android:numColumns="5"
+        tools:listitem="@layout/item_photo" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_simple.xml
+++ b/app/src/main/res/layout/activity_simple.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ activity_main.xml
+  ~ activity_simplele.xml
   ~
   ~ Copyright (c) 2015 Auth0 (http://auth0.com)
   ~
@@ -30,7 +30,7 @@
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context="com.auth0.android.facebook.app.MainActivity">
+    tools:context=".SimpleActivity">
 
     <TextView
         android:id="@+id/textView"

--- a/app/src/main/res/layout/item_photo.xml
+++ b/app/src/main/res/layout/item_photo.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ auth0.xml
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ activity_simplele.xml
   ~
   ~ Copyright (c) 2015 Auth0 (http://auth0.com)
   ~
@@ -22,8 +21,16 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   ~ THE SOFTWARE.
   -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="80dp"
+    android:layout_height="80dp"
+    android:padding="5dp"
+    android:orientation="vertical">
 
-<resources>
-  <string name="com_auth0_client_id">hGou2NwxDfWEPI93dfcI7yilPf8ZPbfD</string>
-  <string name="com_auth0_domain">lbalmaceda.auth0.com</string>
-</resources>
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="centerCrop" />
+
+</LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
@@ -15,6 +15,7 @@ allprojects {
     group = GROUP
 
     repositories {
+        mavenLocal()
         jcenter()
     }
 }
@@ -25,7 +26,7 @@ ext.libraries = [
                 dependencies.create('junit:junit:4.11') {
                     exclude module: 'hamcrest-core'
                 },
-                'org.robolectric:robolectric:3.1.1',
+                'org.robolectric:robolectric:3.1.2',
                 'org.hamcrest:hamcrest-integration:1.3',
                 'org.hamcrest:hamcrest-core:1.3',
                 'org.hamcrest:hamcrest-library:1.3',

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
@@ -38,6 +38,6 @@ ext.libraries = [
 
 ext.compile = [
         minSdk: 15,
-        maxSdk: 23,
-        buildToolsVersion: "23.0.2"
+        maxSdk: 24,
+        buildToolsVersion: "24.0.2"
 ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 22 10:47:59 ART 2016
+#Tue Sep 06 15:06:05 ART 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -28,8 +28,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile libraries.app_compat
-    compile 'com.auth0.android:auth0:1.0.0-beta.3'
-    compile 'com.facebook.android:facebook-android-sdk:4.14.0'
+    compile 'com.auth0.android:auth0:1.0.0-rc.1-SNAPSHOT'
+    compile 'com.facebook.android:facebook-android-sdk:4.15.0'
     testCompile libraries.testing
 }
 

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile libraries.app_compat
-    compile 'com.auth0.android:auth0:1.0.0-rc.1-SNAPSHOT'
+    compile 'com.auth0.android:auth0:1.0.1'
     compile 'com.facebook.android:facebook-android-sdk:4.15.0'
     testCompile libraries.testing
 }

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookApiHelper.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookApiHelper.java
@@ -16,6 +16,7 @@ class FacebookApiHelper {
 
     private final FacebookCallback<LoginResult> facebookCallback;
     private CallbackManager callbackManager;
+    private boolean forceRequestAccount;
 
     public FacebookApiHelper(FacebookCallback<LoginResult> facebookCallback) {
         this.facebookCallback = facebookCallback;
@@ -28,11 +29,23 @@ class FacebookApiHelper {
         } else {
             FacebookSdk.sdkInitialize(activity, requestCode);
         }
+        if (forceRequestAccount){
+            logout();
+        }
         //Use callbackRequestCodeOffset as the requestCode because Login RC is internally defined as "offset + 0".
         //see https://github.com/facebook/facebook-android-sdk/blob/master/facebook/src/main/java/com/facebook/internal/CallbackManagerImpl.java#L92
         callbackManager = CallbackManager.Factory.create();
         LoginManager.getInstance().registerCallback(callbackManager, facebookCallback);
         LoginManager.getInstance().logInWithReadPermissions(activity, permissions);
+    }
+
+    /**
+     * Whether it should clear the session and logout any existing user before trying to authenticate or not.
+     *
+     * @param forceRequestAccount the new force flag value.
+     */
+    public void forceRequestAccount(boolean forceRequestAccount) {
+        this.forceRequestAccount = forceRequestAccount;
     }
 
     public void logout() {

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthHandler.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthHandler.java
@@ -1,0 +1,30 @@
+package com.auth0.android.facebook;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.provider.AuthHandler;
+import com.auth0.android.provider.AuthProvider;
+
+public class FacebookAuthHandler implements AuthHandler {
+
+    private final FacebookAuthProvider provider;
+
+    public FacebookAuthHandler(@NonNull AuthenticationAPIClient apiClient) {
+        this(new FacebookAuthProvider(apiClient));
+    }
+
+    public FacebookAuthHandler(@NonNull FacebookAuthProvider provider) {
+        this.provider = provider;
+    }
+
+    @Nullable
+    @Override
+    public AuthProvider providerFor(@NonNull String strategy, @NonNull String connection) {
+        if ("facebook".equals(connection)) {
+            return provider;
+        }
+        return null;
+    }
+}

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthProvider.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthProvider.java
@@ -127,20 +127,20 @@ public class FacebookAuthProvider extends AuthProvider {
                     requestAuth0Token(loginResult.getAccessToken().getToken());
                 } else {
                     Log.w(TAG, "Some permissions were not granted: " + loginResult.getRecentlyDeniedPermissions().toString());
-                    callback.onFailure(R.string.com_auth0_facebook_authentication_failed_missing_permissions_title, R.string.com_auth0_facebook_authentication_failed_missing_permissions_message, null);
+                    getCallback().onFailure(new AuthenticationException("Some of the requested permissions were not granted by the user."));
                 }
             }
 
             @Override
             public void onCancel() {
                 Log.w(TAG, "User cancelled the log in dialog");
-                callback.onFailure(R.string.com_auth0_facebook_authentication_cancelled_title, R.string.com_auth0_facebook_authentication_cancelled_error_message, null);
+                getCallback().onFailure(new AuthenticationException("User cancelled the authentication consent dialog."));
             }
 
             @Override
             public void onError(FacebookException error) {
                 Log.e(TAG, "Error on log in: " + error.getMessage());
-                callback.onFailure(R.string.com_auth0_facebook_authentication_failed_title, R.string.com_auth0_facebook_authentication_failed_message, error);
+                getCallback().onFailure(new AuthenticationException(error.getMessage()));
             }
         };
     }
@@ -150,12 +150,12 @@ public class FacebookAuthProvider extends AuthProvider {
                 .start(new AuthenticationCallback<Credentials>() {
                     @Override
                     public void onSuccess(Credentials credentials) {
-                        callback.onSuccess(credentials);
+                        getCallback().onSuccess(credentials);
                     }
 
                     @Override
                     public void onFailure(AuthenticationException error) {
-                        callback.onFailure(R.string.com_auth0_facebook_authentication_failed_title, R.string.com_auth0_facebook_authentication_failed_message, error);
+                        getCallback().onFailure(error);
                     }
                 });
     }

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthProvider.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthProvider.java
@@ -29,6 +29,7 @@ public class FacebookAuthProvider extends AuthProvider {
     private Collection<String> permissions;
     private String connectionName;
     private FacebookApiHelper apiHelper;
+    private boolean forceRequestAccount;
 
     /**
      * @param client an Auth0 AuthenticationAPIClient instance
@@ -50,6 +51,15 @@ public class FacebookAuthProvider extends AuthProvider {
     }
 
     /**
+     * Whether it should clear the session and logout any existing user before trying to authenticate or not.
+     *
+     * @param forceRequestAccount the new force flag value.
+     */
+    public void forceRequestAccount(boolean forceRequestAccount) {
+        this.forceRequestAccount = forceRequestAccount;
+    }
+
+    /**
      * Change the default connection to use when requesting the token to Auth0 server. By default this value is "facebook".
      *
      * @param connection that will be used to authenticate the user against Auth0.
@@ -60,7 +70,7 @@ public class FacebookAuthProvider extends AuthProvider {
 
     @Override
     protected void requestAuth(Activity activity, int requestCode) {
-        apiHelper = createApiHelper(activity);
+        apiHelper = createApiHelper(forceRequestAccount);
         apiHelper.login(activity, requestCode, permissions);
     }
 
@@ -95,7 +105,6 @@ public class FacebookAuthProvider extends AuthProvider {
         }
     }
 
-
     Collection<String> getPermissions() {
         return permissions;
     }
@@ -104,8 +113,10 @@ public class FacebookAuthProvider extends AuthProvider {
         return connectionName;
     }
 
-    FacebookApiHelper createApiHelper(Activity activity) {
-        return new FacebookApiHelper(createFacebookCallback());
+    FacebookApiHelper createApiHelper(boolean forceRequestAccount) {
+        final FacebookApiHelper helper = new FacebookApiHelper(createFacebookCallback());
+        helper.forceRequestAccount(forceRequestAccount);
+        return helper;
     }
 
     FacebookCallback<LoginResult> createFacebookCallback() {
@@ -116,14 +127,14 @@ public class FacebookAuthProvider extends AuthProvider {
                     requestAuth0Token(loginResult.getAccessToken().getToken());
                 } else {
                     Log.w(TAG, "Some permissions were not granted: " + loginResult.getRecentlyDeniedPermissions().toString());
-                    callback.onFailure(R.string.com_auth0_facebook_authentication_failed_title, R.string.com_auth0_facebook_authentication_failed_missing_permissions_message, null);
+                    callback.onFailure(R.string.com_auth0_facebook_authentication_failed_missing_permissions_title, R.string.com_auth0_facebook_authentication_failed_missing_permissions_message, null);
                 }
             }
 
             @Override
             public void onCancel() {
                 Log.w(TAG, "User cancelled the log in dialog");
-                callback.onFailure(R.string.com_auth0_facebook_authentication_failed_title, R.string.com_auth0_facebook_authentication_cancelled_error_message, null);
+                callback.onFailure(R.string.com_auth0_facebook_authentication_cancelled_title, R.string.com_auth0_facebook_authentication_cancelled_error_message, null);
             }
 
             @Override

--- a/lock-facebook/src/main/res/values/strings.xml
+++ b/lock-facebook/src/main/res/values/strings.xml
@@ -23,8 +23,12 @@
   -->
 
 <resources>
-    <string name="com_auth0_facebook_authentication_failed_title">Failed to authenticate with Facebook</string>
-    <string name="com_auth0_facebook_authentication_failed_message">Couldn\'t login with your Facebook Account</string>
-    <string name="com_auth0_facebook_authentication_failed_missing_permissions_message">Some of the requested permissions were not granted.</string>
-    <string name="com_auth0_facebook_authentication_cancelled_error_message">You need to authorize the application</string>
+    <string name="com_auth0_facebook_authentication_failed_title">Failed to login with Facebook</string>
+    <string name="com_auth0_facebook_authentication_failed_message">We were unable to login with your Facebook account, please try again.</string>
+
+    <string name="com_auth0_facebook_authentication_failed_missing_permissions_title">Couldn\'t login with Facebook</string>
+    <string name="com_auth0_facebook_authentication_failed_missing_permissions_message">Please grant the requested permissions to login with Facebook.</string>
+
+    <string name="com_auth0_facebook_authentication_cancelled_title">Couldn\'t login with Facebook</string>
+    <string name="com_auth0_facebook_authentication_cancelled_error_message">Please authorize the application to login with Facebook.</string>
 </resources>

--- a/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthHandlerTest.java
+++ b/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthHandlerTest.java
@@ -1,0 +1,40 @@
+package com.auth0.android.facebook;
+
+import com.auth0.android.provider.AuthProvider;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class FacebookAuthHandlerTest {
+
+    private FacebookAuthProvider provider;
+    private FacebookAuthHandler handler;
+
+    @Before
+    public void setUp() throws Exception {
+        provider = mock(FacebookAuthProvider.class);
+        handler = new FacebookAuthHandler(provider);
+    }
+
+    @Test
+    public void shouldGetFacebookProvider() throws Exception {
+        final AuthProvider p = handler.providerFor("facebook", "facebook");
+        assertThat(p, is(notNullValue()));
+        assertThat(p, is(CoreMatchers.instanceOf(FacebookAuthProvider.class)));
+        assertThat(p, is(equalTo((AuthProvider) provider)));
+    }
+
+    @Test
+    public void shouldGetNullProvider() throws Exception {
+        final AuthProvider p = handler.providerFor("some-strategy", "some-connection");
+        assertThat(p, is(nullValue()));
+    }
+}

--- a/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthProviderMock.java
+++ b/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthProviderMock.java
@@ -1,6 +1,5 @@
 package com.auth0.android.facebook;
 
-import android.app.Activity;
 import android.support.annotation.NonNull;
 
 import com.auth0.android.authentication.AuthenticationAPIClient;
@@ -11,6 +10,7 @@ public class FacebookAuthProviderMock extends FacebookAuthProvider {
 
     private final FacebookApiHelper apiHelper;
     FacebookCallback<LoginResult> facebookCallback;
+    private boolean logoutBeforeLogin;
 
     /**
      * @param client an Auth0 AuthenticationAPIClient instance
@@ -21,8 +21,9 @@ public class FacebookAuthProviderMock extends FacebookAuthProvider {
     }
 
     @Override
-    FacebookApiHelper createApiHelper(Activity activity) {
+    FacebookApiHelper createApiHelper(boolean logoutBeforeLogin) {
         createFacebookCallback();
+        this.logoutBeforeLogin = logoutBeforeLogin;
         return apiHelper;
     }
 
@@ -30,5 +31,9 @@ public class FacebookAuthProviderMock extends FacebookAuthProvider {
     FacebookCallback<LoginResult> createFacebookCallback() {
         facebookCallback = super.createFacebookCallback();
         return facebookCallback;
+    }
+
+    boolean willLogoutBeforeLogin() {
+        return logoutBeforeLogin;
     }
 }

--- a/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthProviderTest.java
+++ b/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthProviderTest.java
@@ -105,7 +105,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldParseAuthorization() {
+    public void shouldParseAuthorization() throws Exception {
         Intent intent = Mockito.mock(Intent.class);
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.authorize(AUTH_REQ_CODE, Activity.RESULT_OK, intent);
@@ -116,7 +116,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldReturnDelegatedParseResult() {
+    public void shouldReturnDelegatedParseResult() throws Exception {
         Intent intent = Mockito.mock(Intent.class);
 
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
@@ -128,18 +128,31 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldDoNothingWhenCalledFromNewIntent() {
+    public void shouldDoNothingWhenCalledFromNewIntent() throws Exception {
         assertThat(provider.authorize(null), is(false));
     }
 
     @Test
-    public void shouldNotRequireAndroidPermissions() {
+    public void shouldNotLogoutBeforeLoginByDefault() throws Exception {
+        provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
+        assertThat(provider.willLogoutBeforeLogin(), is(false));
+    }
+
+    @Test
+    public void shouldLogoutBeforeLoginIfRequested() throws Exception {
+        provider.forceRequestAccount(true);
+        provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
+        assertThat(provider.willLogoutBeforeLogin(), is(true));
+    }
+
+    @Test
+    public void shouldNotRequireAndroidPermissions() throws Exception {
         assertThat(provider.getRequiredAndroidPermissions(), is(notNullValue()));
         assertThat(provider.getRequiredAndroidPermissions(), is(IsArrayWithSize.<String>emptyArray()));
     }
 
     @Test
-    public void shouldNotCallAuth0OAuthEndpointWhenSomePermissionsWereRejected() {
+    public void shouldNotCallAuth0OAuthEndpointWhenSomePermissionsWereRejected() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         final AuthenticationRequest request = Mockito.mock(AuthenticationRequest.class);
         Mockito.when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME)).thenReturn(request);
@@ -149,7 +162,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldFailWithTextWhenSomePermissionsWereRejected() {
+    public void shouldFailWithTextWhenSomePermissionsWereRejected() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         final AuthenticationRequest request = Mockito.mock(AuthenticationRequest.class);
         Mockito.when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME)).thenReturn(request);
@@ -160,12 +173,12 @@ public class FacebookAuthProviderTest {
         ArgumentCaptor<Integer> messageResCaptor = ArgumentCaptor.forClass(Integer.class);
         Mockito.verify(callback).onFailure(titleResCaptor.capture(), messageResCaptor.capture(), throwableCaptor.capture());
         assertThat(throwableCaptor.getValue(), is(nullValue()));
-        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_title));
+        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_missing_permissions_title));
         assertThat(messageResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_missing_permissions_message));
     }
 
     @Test
-    public void shouldCallAuth0OAuthEndpointWhenFacebookTokenIsReceived() {
+    public void shouldCallAuth0OAuthEndpointWhenFacebookTokenIsReceived() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         final AuthenticationRequest request = Mockito.mock(AuthenticationRequest.class);
         Mockito.when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME)).thenReturn(request);
@@ -175,7 +188,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldCallAuth0OAuthEndpointWithCustomConnectionNameWhenGoogleTokenIsReceived() {
+    public void shouldCallAuth0OAuthEndpointWithCustomConnectionNameWhenGoogleTokenIsReceived() throws Exception {
         provider.setConnection("my-custom-connection");
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         final AuthenticationRequest request = Mockito.mock(AuthenticationRequest.class);
@@ -186,7 +199,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldFailWithTextWhenFacebookRequestFailed() {
+    public void shouldFailWithTextWhenFacebookRequestFailed() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.facebookCallback.onError(new FacebookException("error"));
 
@@ -200,7 +213,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldFailWithTextWhenFacebookRequestIsCancelled() {
+    public void shouldFailWithTextWhenFacebookRequestIsCancelled() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.facebookCallback.onCancel();
 
@@ -209,12 +222,12 @@ public class FacebookAuthProviderTest {
         ArgumentCaptor<Integer> messageResCaptor = ArgumentCaptor.forClass(Integer.class);
         Mockito.verify(callback).onFailure(titleResCaptor.capture(), messageResCaptor.capture(), throwableCaptor.capture());
         assertThat(throwableCaptor.getValue(), is(nullValue()));
-        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_title));
+        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_cancelled_title));
         assertThat(messageResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_cancelled_error_message));
     }
 
     @Test
-    public void shouldFailWithTextWhenCredentialsRequestFailed() {
+    public void shouldFailWithTextWhenCredentialsRequestFailed() throws Exception {
         final AuthenticationRequest authRequest = new AuthenticationRequestMock(false);
         Mockito.when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME))
                 .thenReturn(authRequest);
@@ -232,7 +245,7 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldSucceedIfCredentialsRequestSucceeded() {
+    public void shouldSucceedIfCredentialsRequestSucceeded() throws Exception {
         final AuthenticationRequest authRequest = new AuthenticationRequestMock(true);
         Mockito.when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME))
                 .thenReturn(authRequest);
@@ -247,14 +260,14 @@ public class FacebookAuthProviderTest {
     }
 
     @Test
-    public void shouldLogoutOnClearSession() {
+    public void shouldLogoutOnClearSession() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.clearSession();
         Mockito.verify(apiHelper).logout();
     }
 
     @Test
-    public void shouldLogoutOnStop() {
+    public void shouldLogoutOnStop() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.stop();
         Mockito.verify(apiHelper).logout();

--- a/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthProviderTest.java
+++ b/lock-facebook/src/test/java/com/auth0/android/facebook/FacebookAuthProviderTest.java
@@ -29,7 +29,6 @@ import edu.emory.mathcs.backport.java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
@@ -168,13 +167,11 @@ public class FacebookAuthProviderTest {
         Mockito.when(client.loginWithOAuthAccessToken(TOKEN, CONNECTION_NAME)).thenReturn(request);
         provider.facebookCallback.onSuccess(createLoginResultFromToken(TOKEN, false));
 
-        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        ArgumentCaptor<Integer> titleResCaptor = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Integer> messageResCaptor = ArgumentCaptor.forClass(Integer.class);
-        Mockito.verify(callback).onFailure(titleResCaptor.capture(), messageResCaptor.capture(), throwableCaptor.capture());
-        assertThat(throwableCaptor.getValue(), is(nullValue()));
-        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_missing_permissions_title));
-        assertThat(messageResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_missing_permissions_message));
+        ArgumentCaptor<AuthenticationException> throwableCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
+        Mockito.verify(callback).onFailure(throwableCaptor.capture());
+        final AuthenticationException exception = throwableCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getMessage(), is("Some of the requested permissions were not granted by the user."));
     }
 
     @Test
@@ -201,15 +198,13 @@ public class FacebookAuthProviderTest {
     @Test
     public void shouldFailWithTextWhenFacebookRequestFailed() throws Exception {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
-        provider.facebookCallback.onError(new FacebookException("error"));
+        provider.facebookCallback.onError(new FacebookException("facebook error"));
 
-        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        ArgumentCaptor<Integer> titleResCaptor = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Integer> messageResCaptor = ArgumentCaptor.forClass(Integer.class);
-        Mockito.verify(callback).onFailure(titleResCaptor.capture(), messageResCaptor.capture(), throwableCaptor.capture());
-        assertThat(throwableCaptor.getValue(), is(instanceOf(FacebookException.class)));
-        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_title));
-        assertThat(messageResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_message));
+        ArgumentCaptor<AuthenticationException> throwableCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
+        Mockito.verify(callback).onFailure(throwableCaptor.capture());
+        final AuthenticationException exception = throwableCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getMessage(), is("facebook error"));
     }
 
     @Test
@@ -217,13 +212,11 @@ public class FacebookAuthProviderTest {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.facebookCallback.onCancel();
 
-        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        ArgumentCaptor<Integer> titleResCaptor = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Integer> messageResCaptor = ArgumentCaptor.forClass(Integer.class);
-        Mockito.verify(callback).onFailure(titleResCaptor.capture(), messageResCaptor.capture(), throwableCaptor.capture());
-        assertThat(throwableCaptor.getValue(), is(nullValue()));
-        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_cancelled_title));
-        assertThat(messageResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_cancelled_error_message));
+        ArgumentCaptor<AuthenticationException> throwableCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
+        Mockito.verify(callback).onFailure(throwableCaptor.capture());
+        final AuthenticationException exception = throwableCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception.getMessage(), is("User cancelled the authentication consent dialog."));
     }
 
     @Test
@@ -235,13 +228,10 @@ public class FacebookAuthProviderTest {
         provider.start(activity, callback, PERMISSION_REQ_CODE, AUTH_REQ_CODE);
         provider.facebookCallback.onSuccess(createLoginResultFromToken(TOKEN, true));
 
-        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        ArgumentCaptor<Integer> titleResCaptor = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Integer> messageResCaptor = ArgumentCaptor.forClass(Integer.class);
-        Mockito.verify(callback).onFailure(titleResCaptor.capture(), messageResCaptor.capture(), throwableCaptor.capture());
-        assertThat(throwableCaptor.getValue(), is(instanceOf(AuthenticationException.class)));
-        assertThat(titleResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_title));
-        assertThat(messageResCaptor.getValue(), is(R.string.com_auth0_facebook_authentication_failed_message));
+        ArgumentCaptor<AuthenticationException> throwableCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
+        Mockito.verify(callback).onFailure(throwableCaptor.capture());
+        final AuthenticationException exception = throwableCaptor.getValue();
+        assertThat(exception, is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
Split the demo activity in two:
1) `SimpleActivity` shows *Log in* and *Log out* buttons, and displays the user access_token when the user logs in.
2) `PhotosActivity` shows a *Log in* button to open **Lock** and authenticate with Facebook (also native). After the user logs in, a list will be populated with his albums covers.

The class `FacebookAuthHandler` is provided implementing the `AuthHandler` interface, so the dev can use it directly with **Lock**. It has 2 constructors: 
* one receiving the `AuthProvider` instance, for him to customize it (scopes, permissions, etc) before instantiating the AuthHandler.
* one receiving the Auth0 `apiClient`, if the user doesn't want to customize anything.

> This PR depends on https://github.com/auth0/Lock-Facebook.Android/pull/9 and also needs `Auth0.Android` to make the callback accesible from the subclass https://github.com/auth0/Auth0.Android/pull/27  (merge and release, then update dependency on this PR) 