### PR TITLE
Support authentication parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ jdk:
 android:
   components:
   - tools
-  - build-tools-24.0.2
-  - android-24
+  - build-tools-25.0.1
+  - android-25
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
-  - addon-google_apis-google-24
+  - addon-google_apis-google-25
 script:
 - "./gradlew clean test --continue"
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
 android:
   components:
   - tools
-  - build-tools-25.0.1
+  - build-tools-25.0.2
   - android-25
   - extra-google-google_play_services
   - extra-google-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
-        applicationId "com.auth0.android.facebook.app"
+        applicationId "com.auth0.android.native.app"
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 2
@@ -27,8 +27,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-facebook')
-    compile 'com.auth0.android:lock:2.2.0'
+    compile 'com.auth0.android:lock:2.3.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:support-v4:25.0.1'
-    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:support-v4:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.1.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         applicationId "com.auth0.android.facebook.app"
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 2
         versionName "2.0.0"
     }
@@ -27,8 +27,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-facebook')
-    compile 'com.auth0.android:lock:2.0.0'
+    compile 'com.auth0.android:lock:2.2.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:support-v4:24.2.1'
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.0.1'
 }

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
@@ -41,6 +41,7 @@ public class PhotosActivity extends AppCompatActivity {
     private PhotosAdapter adapter;
     private List<String> photos;
     private ProgressBar progressBar;
+    private Button loginButton;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -56,7 +57,7 @@ public class PhotosActivity extends AppCompatActivity {
                 .closable(true)
                 .build(this);
 
-        Button loginButton = (Button) findViewById(R.id.loginButton);
+        loginButton = (Button) findViewById(R.id.loginButton);
         loginButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -128,6 +129,7 @@ public class PhotosActivity extends AppCompatActivity {
         public void onAuthentication(Credentials credentials) {
             Log.i(TAG, "Auth ok! User has given us all facebook requested permissions.");
             progressBar.setVisibility(View.VISIBLE);
+            loginButton.setEnabled(false);
             fetchAlbums();
         }
 

--- a/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
+++ b/app/src/main/java/com/auth0/android/facebook/app/PhotosActivity.java
@@ -48,6 +48,7 @@ public class PhotosActivity extends AppCompatActivity {
         setContentView(R.layout.activity_photos);
 
         FacebookAuthProvider provider = new FacebookAuthProvider(new AuthenticationAPIClient(getAccount()));
+        provider.rememberLastLogin(true);
         provider.setPermissions(Arrays.asList("public_profile", "user_photos"));
         lock = Lock.newBuilder(getAccount(), authCallback)
                 .withAuthHandlers(new FacebookAuthHandler(provider))

--- a/app/src/main/res/layout/activity_chooser.xml
+++ b/app/src/main/res/layout/activity_chooser.xml
@@ -41,18 +41,18 @@
         android:textSize="20sp" />
 
     <Button
-        android:id="@+id/tokenLoginButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="Simple Log In (TOKEN)" />
-
-    <Button
         android:id="@+id/photosLoginButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/tokenLoginButton"
-        android:layout_centerHorizontal="true"
+        android:layout_centerInParent="true"
         android:text="Log In Using Lock (PHOTO ALBUMS)" />
+
+    <Button
+        android:id="@+id/tokenLoginButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/photosLoginButton"
+        android:layout_centerHorizontal="true"
+        android:text="Simple Log In (TOKEN)" />
 
 </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -6,12 +6,12 @@ version = semver.stringVersion
 logger.lifecycle("Using version ${version} for ${name}")
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
     }
 
     buildTypes {
@@ -45,8 +45,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.auth0.android:auth0:1.0.1'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.auth0.android:auth0:1.1.2'
     compile 'com.facebook.android:facebook-android-sdk:4.16.0'
     testCompile('junit:junit:4.11') {
         exclude module: 'hamcrest-core'

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -7,7 +7,7 @@ logger.lifecycle("Using version ${version} for ${name}")
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15
@@ -45,9 +45,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.auth0.android:auth0:1.1.2'
-    compile 'com.facebook.android:facebook-android-sdk:4.16.0'
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.auth0.android:auth0:1.4.0'
+    compile 'com.facebook.android:facebook-android-sdk:4.18.0'
     testCompile('junit:junit:4.11') {
         exclude module: 'hamcrest-core'
     }

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthProvider.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookAuthProvider.java
@@ -152,6 +152,7 @@ public class FacebookAuthProvider extends AuthProvider {
     private void requestAuth0Token(String token) {
         final AuthCallback callback = getSafeCallback();
         auth0.loginWithOAuthAccessToken(token, connectionName)
+                .addAuthenticationParameters(getParameters())
                 .start(new AuthenticationCallback<Credentials>() {
                     @Override
                     public void onSuccess(Credentials credentials) {


### PR DESCRIPTION
This Facebook provider is child of `AuthProvider`. We can call `provider.setParameters()` passing the map with the values and they will be sent with the request to the Auth0 server.

Related to https://github.com/auth0/Lock-Google.Android/pull/29
