### PR TITLE
Always accept a Custom Request code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.auth0.android.native.app"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "com.auth0.android.native.app"
@@ -27,8 +27,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':lock-facebook')
-    compile 'com.auth0.android:lock:2.4.0'
+    compile 'com.auth0.android:lock:2.5.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:support-v4:25.1.0'
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:support-v4:25.0.0'
+    compile 'com.android.support:appcompat-v7:25.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
         <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="@string/app_name"/>
+            android:label="@string/app_name" />
 
         <meta-data
             android:name="com.facebook.sdk.ApplicationId"

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -22,7 +22,7 @@ oss {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 15
@@ -60,9 +60,9 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.auth0.android:auth0:1.6.0'
-    compile 'com.facebook.android:facebook-android-sdk:4.20.0'
+    compile 'com.android.support:appcompat-v7:25.0.0'
+    compile 'com.auth0.android:auth0:1.8.0'
+    compile 'com.facebook.android:facebook-android-sdk:4.22.0'
     testCompile('junit:junit:4.11') {
         exclude module: 'hamcrest-core'
     }

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -62,8 +62,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.auth0.android:auth0:1.6.0'
-    compile 'com.facebook.android:facebook-android-sdk:4.18.0'
-
+    compile 'com.facebook.android:facebook-android-sdk:4.20.0'
     testCompile('junit:junit:4.11') {
         exclude module: 'hamcrest-core'
     }

--- a/lock-facebook/build.gradle
+++ b/lock-facebook/build.gradle
@@ -22,7 +22,7 @@ oss {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15

--- a/lock-facebook/src/main/AndroidManifest.xml
+++ b/lock-facebook/src/main/AndroidManifest.xml
@@ -26,6 +26,8 @@
     package="com.auth0.android.facebook">
 
     <application>
-        <activity android:name=".FacebookSignInDelegateActivity" />
+        <activity
+            android:name=".FacebookSignInDelegateActivity"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
     </application>
 </manifest>

--- a/lock-facebook/src/main/AndroidManifest.xml
+++ b/lock-facebook/src/main/AndroidManifest.xml
@@ -22,4 +22,10 @@
   ~ THE SOFTWARE.
   -->
 
-<manifest package="com.auth0.android.facebook" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.auth0.android.facebook">
+
+    <application>
+        <activity android:name=".FacebookSignInDelegateActivity" />
+    </application>
+</manifest>

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookApi.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookApi.java
@@ -9,11 +9,7 @@ import com.facebook.FacebookException;
 import com.facebook.login.LoginManager;
 import com.facebook.login.LoginResult;
 
-import java.util.ArrayList;
 import java.util.Collection;
-
-import static com.auth0.android.facebook.FacebookSignInDelegateActivity.FACEBOOK_PERMISSIONS_EXTRA;
-import static com.auth0.android.facebook.FacebookSignInDelegateActivity.PROVIDER_REQUEST_CODE_EXTRA;
 
 class FacebookApi {
 
@@ -42,9 +38,7 @@ class FacebookApi {
             }
         });
 
-        Intent delegateIntent = new Intent(activity, FacebookSignInDelegateActivity.class);
-        delegateIntent.putStringArrayListExtra(FACEBOOK_PERMISSIONS_EXTRA, new ArrayList<>(permissions));
-        activity.startActivityForResult(delegateIntent, requestCode);
+        FacebookSignInDelegateActivity.signIn(activity, requestCode, permissions);
     }
 
     public void logout() {
@@ -52,7 +46,7 @@ class FacebookApi {
     }
 
     public boolean finishLogin(int requestCode, int resultCode, Intent intent) {
-        return callbackManager.onActivityResult(intent.getIntExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode), resultCode, intent);
+        return FacebookSignInDelegateActivity.finishSignIn(callbackManager, requestCode, resultCode, intent);
     }
 
     interface Callback {

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookApi.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookApi.java
@@ -2,7 +2,6 @@ package com.auth0.android.facebook;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.util.Log;
 
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
@@ -53,11 +52,7 @@ class FacebookApi {
     }
 
     public boolean finishLogin(int requestCode, int resultCode, Intent intent) {
-        if (intent.hasExtra(PROVIDER_REQUEST_CODE_EXTRA)) {
-            return callbackManager.onActivityResult(intent.getIntExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode), resultCode, intent);
-        }
-        Log.w(TAG, "The received Request Code is invalid and the result will be ignored.");
-        return false;
+        return callbackManager.onActivityResult(intent.getIntExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode), resultCode, intent);
     }
 
     interface Callback {

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookSignInDelegateActivity.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookSignInDelegateActivity.java
@@ -3,17 +3,21 @@ package com.auth0.android.facebook;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.facebook.CallbackManager;
 import com.facebook.login.LoginManager;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 public class FacebookSignInDelegateActivity extends Activity {
 
-    public static final String FACEBOOK_PERMISSIONS_EXTRA = "com.auth0.android.facebook.FACEBOOK_PERMISSIONS";
-    public static final String PROVIDER_REQUEST_CODE_EXTRA = "com.auth0.android.facebook.PROVIDER_REQUEST_CODE";
+    private static final String FACEBOOK_PERMISSIONS_EXTRA = "com.auth0.android.facebook.FACEBOOK_PERMISSIONS";
+    private static final String PROVIDER_REQUEST_CODE_EXTRA = "com.auth0.android.facebook.PROVIDER_REQUEST_CODE";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -31,5 +35,16 @@ public class FacebookSignInDelegateActivity extends Activity {
         data.putExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode);
         setResult(resultCode, data);
         finish();
+    }
+
+    static void signIn(@NonNull Activity activity, int requestCode, @NonNull Collection<String> permissions) {
+        Intent delegateIntent = new Intent(activity, FacebookSignInDelegateActivity.class);
+        delegateIntent.putStringArrayListExtra(FACEBOOK_PERMISSIONS_EXTRA, new ArrayList<>(permissions));
+        activity.startActivityForResult(delegateIntent, requestCode);
+    }
+
+    static boolean finishSignIn(@NonNull CallbackManager callbackManager, int requestCode, int resultCode, @NonNull Intent intent) {
+        int reqCode = intent.getIntExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode);
+        return callbackManager.onActivityResult(reqCode, resultCode, intent);
     }
 }

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookSignInDelegateActivity.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookSignInDelegateActivity.java
@@ -1,0 +1,39 @@
+package com.auth0.android.facebook;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+
+import com.facebook.FacebookSdk;
+import com.facebook.login.LoginManager;
+
+import java.util.Collections;
+import java.util.List;
+
+public class FacebookSignInDelegateActivity extends AppCompatActivity {
+
+    public static final String FACEBOOK_PERMISSIONS_EXTRA = "com.auth0.android.facebook.FACEBOOK_PERMISSIONS";
+    public static final String PROVIDER_REQUEST_CODE_EXTRA = "com.auth0.android.facebook.PROVIDER_REQUEST_CODE";
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        List<String> permissions = Collections.emptyList();
+        if (getIntent().hasExtra(FACEBOOK_PERMISSIONS_EXTRA)) {
+            permissions = getIntent().getStringArrayListExtra(FACEBOOK_PERMISSIONS_EXTRA);
+        }
+        LoginManager.getInstance().logInWithReadPermissions(this, permissions);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (FacebookSdk.isFacebookRequestCode(requestCode)) {
+            data.putExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode);
+            setResult(resultCode, data);
+            finish();
+            return;
+        }
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+}

--- a/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookSignInDelegateActivity.java
+++ b/lock-facebook/src/main/java/com/auth0/android/facebook/FacebookSignInDelegateActivity.java
@@ -1,17 +1,16 @@
 package com.auth0.android.facebook;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
 
-import com.facebook.FacebookSdk;
 import com.facebook.login.LoginManager;
 
 import java.util.Collections;
 import java.util.List;
 
-public class FacebookSignInDelegateActivity extends AppCompatActivity {
+public class FacebookSignInDelegateActivity extends Activity {
 
     public static final String FACEBOOK_PERMISSIONS_EXTRA = "com.auth0.android.facebook.FACEBOOK_PERMISSIONS";
     public static final String PROVIDER_REQUEST_CODE_EXTRA = "com.auth0.android.facebook.PROVIDER_REQUEST_CODE";
@@ -28,12 +27,9 @@ public class FacebookSignInDelegateActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (FacebookSdk.isFacebookRequestCode(requestCode)) {
-            data.putExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode);
-            setResult(resultCode, data);
-            finish();
-            return;
-        }
         super.onActivityResult(requestCode, resultCode, data);
+        data.putExtra(PROVIDER_REQUEST_CODE_EXTRA, requestCode);
+        setResult(resultCode, data);
+        finish();
     }
 }


### PR DESCRIPTION
As of `4.19.0` of the Facebook android sdk, we [no longer can](https://developers.facebook.com/docs/android/change-log-4x) specify a custom request_code. Lock.Android needs this to call the provider and get a safe result back. In this PR I added a Activity to do the request_code dance. Internally we listen for the Facebook default request_code and call the original caller activity with the request_code they first asked.